### PR TITLE
Fix non-base-game music thumbnails being blank in "Favourite Music" dialog

### DIFF
--- a/NRaasMasterController/MasterControllerSpace/SelectionCriteria/PreferenceMusic.cs
+++ b/NRaasMasterController/MasterControllerSpace/SelectionCriteria/PreferenceMusic.cs
@@ -46,7 +46,7 @@ namespace NRaas.MasterControllerSpace.SelectionCriteria
 
                 mName = CASCharacter.GetFavoriteMusic(value);
 
-                SetThumbnail(ResourceKey.CreatePNGKey(CASCharacter.GetFavoriteMusicPngName(value), 0x0));
+                SetThumbnail(ResourceKey.CreatePNGKey(CASCharacter.GetFavoriteMusicPngName(value), ResourceUtils.ProductVersionToGroupId(Responder.Instance.GetProductVersionForStereoStation(value))));
             }
         }
     }


### PR DESCRIPTION
This PR fixes the issue whereby music genres from expansions and other add-on content have blank icons in the MasterController Cheats "Favourite Music" dialog menu.