### PR TITLE
More fixes for data loss during world transition

### DIFF
--- a/NRaasTraveler/TravelerSpace/Helpers/CrossWorldControl.cs
+++ b/NRaasTraveler/TravelerSpace/Helpers/CrossWorldControl.cs
@@ -259,6 +259,8 @@ namespace NRaas.TravelerSpace.Helpers
             int mFemalePreference;
             CASAgeGenderFlags mPregnantGender;
 
+            bool wasAdopted;
+
             OutfitCategories mPreviousOutfitCategory = OutfitCategories.None;
             int mPreviousOutfitIndex;
 
@@ -314,6 +316,8 @@ namespace NRaas.TravelerSpace.Helpers
 
                 mMalePreference = sim.mGenderPreferenceMale;
                 mFemalePreference = sim.mGenderPreferenceFemale;
+
+                wasAdopted = sim.WasAdopted;
 
                 if (sim.CreatedSim != null)
                 {
@@ -417,6 +421,8 @@ namespace NRaas.TravelerSpace.Helpers
                 {
                     sim.mGenderPreferenceMale = mMalePreference;
                     sim.mGenderPreferenceFemale = mFemalePreference;
+
+                    sim.WasAdopted = wasAdopted;
 
                     if (sim.Pregnancy != null)
                     {

--- a/NRaasTraveler/TravelerSpace/Helpers/SimDescriptionEx.cs
+++ b/NRaasTraveler/TravelerSpace/Helpers/SimDescriptionEx.cs
@@ -208,6 +208,90 @@ namespace NRaas.TravelerSpace.Helpers
 
                 msg += "G";
                 Traveler.InsanityWriteLog(msg);
+
+                Collecting sourceCollectingSkill = source.SkillManager.GetSkill<Collecting>(SkillNames.Collecting);
+                if (sourceCollectingSkill != null)
+                {
+                    Collecting destCollectingSkill = dest.SkillManager.AddElement(SkillNames.Collecting) as Collecting;
+                    if (destCollectingSkill != null)
+                    {
+                        destCollectingSkill.mMushroomsCollected = sourceCollectingSkill.mMushroomsCollected;
+                    }
+                }
+
+                msg += "H";
+                Traveler.InsanityWriteLog(msg);
+
+                SculptingSkill sourceSculptingSkill = source.SkillManager.GetSkill<SculptingSkill>(SkillNames.Sculpting);
+                if (sourceSculptingSkill != null)
+                {
+                    SculptingSkill destSculptingSkill = dest.SkillManager.AddElement(SkillNames.Sculpting) as SculptingSkill;
+                    if (destSculptingSkill != null)
+                    {
+                        destSculptingSkill.mHighestValueSculptureSold = sourceSculptingSkill.mHighestValueSculptureSold;
+                        destSculptingSkill.mTotalMoneyEarned = sourceSculptingSkill.mTotalMoneyEarned;
+                    }
+                }
+
+                msg += "I";
+                Traveler.InsanityWriteLog(msg);
+
+                SocialNetworkingSkill sourceSocialNetworkingSkill = source.SkillManager.GetSkill<SocialNetworkingSkill>(SkillNames.SocialNetworking);
+                if (sourceSocialNetworkingSkill != null)
+                {
+                    SocialNetworkingSkill destSocialNetworkingSkill = dest.SkillManager.AddElement(SkillNames.SocialNetworking) as SocialNetworkingSkill;
+                    if (destSocialNetworkingSkill != null)
+                    {
+                        destSocialNetworkingSkill.mCurrentBlogType = sourceSocialNetworkingSkill.mCurrentBlogType;
+                        destSocialNetworkingSkill.mBlogsCreated = sourceSocialNetworkingSkill.mBlogsCreated;
+                    }
+                }
+
+                msg += "J";
+                Traveler.InsanityWriteLog(msg);
+
+                dest.AlmaMater = source.AlmaMater;
+                dest.mAlmaMaterName = source.mAlmaMaterName;
+                dest.GraduationType = source.GraduationType;
+
+                if (GameUtils.IsAnyTravelBasedWorld())
+                {
+                    CareerManager destCareerManager = dest.CareerManager;
+                    CareerManager sourceCareerManager = source.CareerManager;
+                    if (destCareerManager != null && sourceCareerManager != null)
+                    {
+                        if (destCareerManager.QuitCareers != null)
+                        {
+                            if (sourceCareerManager.QuitCareers != null && sourceCareerManager.QuitCareers.Count > 0)
+                            {
+                                foreach (Occupation occupation in sourceCareerManager.QuitCareers.Values)
+                                {
+                                    if (occupation != null)
+                                    {
+                                        Occupation occupation2 = occupation.Clone();
+                                        if (occupation2 != null)
+                                        {
+                                            occupation2.OwnerDescription = dest;
+                                            destCareerManager.QuitCareers[occupation2.Guid] = occupation2;
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                        if (sourceCareerManager.mRetiredCareer != null && (!GameUtils.IsFutureWorld() || destCareerManager.mRetiredCareer == null || !destCareerManager.mRetiredCareer.AvailableInFutureWorld))
+                        {
+                            Occupation occupation3 = sourceCareerManager.mRetiredCareer.Clone();
+                            if (occupation3 != null)
+                            {
+                                occupation3.OwnerDescription = dest;
+                                destCareerManager.mRetiredCareer = occupation3;
+                            }
+                        }
+                    }
+                }
+
+                msg += "K";
+                Traveler.InsanityWriteLog(msg);
             }
             catch (Exception e)
             {


### PR DESCRIPTION
This PR includes fixes for some data not being transferred during world transition by either EA or Traveler. These issues were discovered by simler90.

Data that was not imported on the first trip:
- information about whether a sim was adopted

Data that was not updated on subsequent trips:
- the amount of money and the highest-valued sculpture the sim has made from the sculpting skill
- the number of mushrooms the sim has collected
- the type of blog the sim has, and the type of 5 star blogs the sim has sold
- graduation information
- career history and retired career