### PR TITLE
Fix the max number of travel actions

### DIFF
--- a/NRaasTraveler/TravelerSpace/States/InWorldStateEx.cs
+++ b/NRaasTraveler/TravelerSpace/States/InWorldStateEx.cs
@@ -45,7 +45,24 @@ namespace NRaas.TravelerSpace.States
             GenerateOffspringEx.PossiblyGenerateOffspring(dyingSims, yearsGone);
 
             int maxActions = StoryProgressionService.kTravellingMaxActions;
-            if (!CrossWorldControl.sRetention.mPerformTravelActions)
+            if (CrossWorldControl.sRetention.mPerformTravelActions && (yearsGone > 0f))
+            {
+                if (AgingManager.Singleton != null)
+                {
+                    int daysGone = (int)(yearsGone * AgingManager.Singleton.SimDaysPerAgingYear);
+                    msg += Common.NewLine + "DaysGone: " + daysGone;
+                    int num = 0;
+                    for (int i = 1; (i <= daysGone) && (num < maxActions); i++)
+                    {
+                        num += RandomUtil.GetInt(StoryProgressionService.kActionsMin, StoryProgressionService.kActionsMax);
+                    }
+                    if (num < maxActions)
+                    {
+                        maxActions = num;
+                    }
+                }
+            }
+            else
             {
                 maxActions = 0;
             }
@@ -446,6 +463,10 @@ namespace NRaas.TravelerSpace.States
                             if ((dyingSims != null) && (AgingManager.NumberAgingYearsElapsed != -1f))
                             {
                                 float yearsGone = GameStates.NumberAgingYearsElapsed - AgingManager.NumberAgingYearsElapsed;
+                                if (AgingManager.NumberAgingYearsElapsed <= 0f)
+                                {
+                                    yearsGone = 0f;
+                                }
 
                                 // Custom function
                                 FixUpAfterTravel(yearsGone, dyingSims);


### PR DESCRIPTION
Fixed an issue where the game would perform EA's travel actions even when traveling to a world for the first time (with the "Perform Travel Actions" option enabled). The number of actions performed now also depends on the number of days that have passed since the last visit to the world, as it doesn't make sense to perform more actions than EA's Story Progression would naturally be able to perform during the player's absence.